### PR TITLE
Highlight 'donate' menu item in the header

### DIFF
--- a/app/assets/stylesheets/partials/_page.scss
+++ b/app/assets/stylesheets/partials/_page.scss
@@ -68,6 +68,9 @@ a {
       color: $dark;
       background-color: $content-background;
     }
+    li:last-child a {
+      color: $warm-highlight;
+    }
   }
   a {
     padding: .5em;

--- a/app/views/application/_header.haml
+++ b/app/views/application/_header.haml
@@ -26,7 +26,7 @@
         = li_selected(:controller => "/api", :action => "howto") do
           = link_to api_howto_path do
             Get the Data
-        = li_selected(:controller => "/static", :action => "donate") do
-          = link_to 'Donate', donate_path
         = li_selected(:controller => "/static", :action => "about") do
           = link_to 'About', about_path
+        = li_selected(:controller => "/static", :action => "donate") do
+          = link_to 'Donate', donate_path


### PR DESCRIPTION
This moves the donation link to the final position in the header menu and highlights it by making it the link orange colour.

Closes #604 

![screen shot 2015-01-23 at 12 34 09 pm](https://cloud.githubusercontent.com/assets/1239550/5868354/4478e082-a2fc-11e4-86c1-fe3b5293492a.png)
![screen shot 2015-01-23 at 12 34 17 pm](https://cloud.githubusercontent.com/assets/1239550/5868353/44766dca-a2fc-11e4-8a22-9a0705a7bc0d.png)
