### PR TITLE
Donate link highlight, target more specifically

### DIFF
--- a/app/assets/stylesheets/partials/_page.scss
+++ b/app/assets/stylesheets/partials/_page.scss
@@ -68,7 +68,7 @@ a {
       color: $dark;
       background-color: $content-background;
     }
-    li:last-child a {
+    a.donate-link-header {
       color: $warm-highlight;
     }
   }

--- a/app/views/application/_header.haml
+++ b/app/views/application/_header.haml
@@ -29,4 +29,4 @@
         = li_selected(:controller => "/static", :action => "about") do
           = link_to 'About', about_path
         = li_selected(:controller => "/static", :action => "donate") do
-          = link_to 'Donate', donate_path
+          = link_to 'Donate', donate_path, class: 'donate-link-header'


### PR DESCRIPTION
This adds a class to the header donate link so that it can be targeted specifically, then changes the css selector to target it with styles. This prevents the menu on the nsw planning theme from being effected.

![screen shot 2015-02-08 at 10 13 37 pm](https://cloud.githubusercontent.com/assets/1239550/6096354/8c09f184-afe0-11e4-846f-2464d4485165.png)
![screen shot 2015-02-08 at 10 13 46 pm](https://cloud.githubusercontent.com/assets/1239550/6096355/8c0af5ac-afe0-11e4-8acb-0fa64dcf7156.png)

Closes #632