### PR TITLE
fix error on /comments by handling case of no application decription

### DIFF
--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -4,8 +4,8 @@
       %h2.comment-address.panel-heading
         In
         %strong #{comment.application.suburb} #{comment.application.state}
-        #{"on “" + truncate(comment.application.description) + "”"}
-        at
+        on
+        = comment.application.description ? "“" + truncate(comment.application.description) + "” at" : "application for"
         #{comment.application.address}
       %blockquote.comment-text= comment_as_html(comment.text)
       %figcaption.comment-meta


### PR DESCRIPTION
provides fallback copy on a comment in the comments index
for when there is no description on the relevant application
fixes #636

![screen shot 2015-02-11 at 11 24 06 am](https://cloud.githubusercontent.com/assets/1239550/6139492/a64ae362-b1e0-11e4-97e6-db4054cc1fec.png)
