### PR TITLE
add 'no lock-in' text aftert subscriptions button

### DIFF
--- a/app/assets/stylesheets/partials/_payment_form.scss
+++ b/app/assets/stylesheets/partials/_payment_form.scss
@@ -69,6 +69,7 @@
   background: darken($light, 8%);
   text-shadow: 0 1px 0 $lightest;
   border-radius: .2em;
+  display: block;
 
   &:hover,
   &:focus {
@@ -85,6 +86,10 @@
 
   &[disabled] {
     color: $font-color;
+  }
+
+  & + p {
+    font-size: 1em;
   }
 }
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -11,3 +11,5 @@
 
     %button{disabled: true, type: 'submit', id: "button-pro-signup", data: {key: Configuration::STRIPE_PUBLISHABLE_KEY, email: (@email if @email)}}
       Subscribe now $99/month
+
+    %p No lock-in. Cancel anytime


### PR DESCRIPTION
Adds a paragraph after the button on the new subscription page to let people know that they can op-out at any time.

![screen shot 2015-02-16 at 10 48 19 am](https://cloud.githubusercontent.com/assets/1239550/6205638/6569ec84-b5c9-11e4-824a-8289c134c917.png)
