### PR TITLE
Fix broken small screen user forms

### DIFF
--- a/app/assets/stylesheets/partials/_form.scss
+++ b/app/assets/stylesheets/partials/_form.scss
@@ -99,6 +99,12 @@ a.btn:hover {
 
 // Special formatting for specific forms
 
+.formtastic.user {
+  input.button {
+    white-space: normal;
+  }
+}
+
 .formtastic#new_comment, .formtastic#new_report {
   @include float-form(100%, 0%, 100%, 0, "buttons-left", "left", "select-auto");
   // Hide the labels

--- a/app/assets/stylesheets/partials/_grid.scss
+++ b/app/assets/stylesheets/partials/_grid.scss
@@ -85,7 +85,7 @@
     }
     // Home page search form should be tweaked
     // Also alert sign up form
-    form.alert, .address-search {
+    form.alert, .address-search, form.user {
       width: 90%;
       margin-left: auto;
       margin-right: auto;


### PR DESCRIPTION
Makes all the test of the user forms visible on small screens:

fixes #643 

Before labels would slip behind inputs:
![screen shot 2015-02-27 at 3 52 29 pm](https://cloud.githubusercontent.com/assets/1239550/6408069/11e09be0-bea1-11e4-9a8e-9b1e60fc8987.png)

Now the forms are centred on small screens and the labels site above the input:
![screen shot 2015-02-27 at 4 22 53 pm](https://cloud.githubusercontent.com/assets/1239550/6408077/30640908-bea1-11e4-89fb-f8cdb59e28aa.png)

Before text in buttons wouldn't wrap:
![screen shot 2015-02-27 at 4 22 34 pm](https://cloud.githubusercontent.com/assets/1239550/6408064/facdf52e-bea0-11e4-8c1e-ab17dd0931a9.png)

Now the text wraps:
![screen shot 2015-02-27 at 4 44 23 pm](https://cloud.githubusercontent.com/assets/1239550/6408062/ec0b944c-bea0-11e4-96bc-6cfc38114fe4.png)
