### PR TITLE
include the 'remember me' checkbox in mobile style

### DIFF
--- a/app/assets/stylesheets/partials/_grid.scss
+++ b/app/assets/stylesheets/partials/_grid.scss
@@ -100,7 +100,7 @@
         font-size: 1.1em;
         margin-bottom: .5em;
       }
-      #{nest("li.stringish, li.string", "label, input")}, .inline-hints  {
+      #{nest("li.stringish, li.string", "label, input")}, .inline-hints, label[for="user_remember_me"]  {
         //li.stringish, li.string, .inline-hints {
         text-align: center;
         width: 100%;
@@ -108,7 +108,7 @@
       #geolocate {
         display: inline-block;
       }
-      .inline-hints {
+      .inline-hints, label[for="user_remember_me"] {
         margin-left: 0;
       }
       .actions {


### PR DESCRIPTION
The checkbox was not included in the mobile styles for forms, so it was getting centred weirdly across different screen sizes.

relates to #643 

Before:
![screen shot 2015-02-27 at 5 20 50 pm](https://cloud.githubusercontent.com/assets/1239550/6408263/0a350bf2-bea5-11e4-9c0d-73ba0670d254.png)
![screen shot 2015-02-27 at 5 20 57 pm](https://cloud.githubusercontent.com/assets/1239550/6408260/0915f2fe-bea5-11e4-9d9e-34ebddcd4993.png)

Now:
![screen shot 2015-02-27 at 5 12 22 pm](https://cloud.githubusercontent.com/assets/1239550/6408268/137241a8-bea5-11e4-8668-90728e608ee1.png)
![screen shot 2015-02-27 at 5 14 52 pm](https://cloud.githubusercontent.com/assets/1239550/6408269/13728118-bea5-11e4-89ed-05f71f019a8b.png)
![screen shot 2015-02-27 at 5 15 02 pm](https://cloud.githubusercontent.com/assets/1239550/6408271/13c140f0-bea5-11e4-8fcb-82afe63df05d.png)
![screen shot 2015-02-27 at 5 15 09 pm](https://cloud.githubusercontent.com/assets/1239550/6408270/138294b8-bea5-11e4-954e-28a3988644dd.png)
