### PR TITLE
Add <title> tag to subscriptions pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@ if ("#button-pro-signup".length) {
   public_key = $('#button-pro-signup').attr('data-key');
   email = $('#button-pro-signup').attr("data-email");
   amount = $('#button-pro-signup').attr("data-amount");
+  submit_block = $('.payment-submit-block');
 
   var handler = StripeCheckout.configure({
     key: public_key,
@@ -21,7 +22,7 @@ if ("#button-pro-signup".length) {
       var tokenInput = $("<input type=hidden name=stripeToken />").val(response.id);
       var emailInput = $("<input type=hidden name=stripeEmail />").val(response.email);
       $("#subscription-payment-form").append(tokenInput).append(emailInput).submit();
-      $('#button-pro-signup').fadeOut('fast', function() {
+      submit_block.fadeOut('fast', function() {
         var processingNotice = $("<p class='form-processing'>Processing ...</p>").fadeIn('slow');
         $("#subscription-payment-form").append(processingNotice);
       });

--- a/app/views/subscriptions/create.html.haml
+++ b/app/views/subscriptions/create.html.haml
@@ -1,3 +1,5 @@
+- content_for :page_title, 'Success, subscription confirmed'
+
 .registration-success-page
   %h1 Success!
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -1,3 +1,5 @@
+- content_for :page_title, 'Get less email & more useful alerts'
+
 .registration-page
   = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do
     %h1 Sift through less email and get more useful&nbsp;alerts

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -12,7 +12,8 @@
     %script{src: "https://checkout.stripe.com/checkout.js"}
 
     %input{type: 'hidden', name: 'stripeAmount', value: @amount}
-    %button{disabled: true, type: 'submit', id: "button-pro-signup", data: {key: Configuration::STRIPE_PUBLISHABLE_KEY, amount: @amount, email: (@email if @email)}}
-      Subscribe now #{@display_amount}/month
+    .payment-submit-block
+      %button{disabled: true, type: 'submit', id: "button-pro-signup", data: {key: Configuration::STRIPE_PUBLISHABLE_KEY, amount: @amount, email: (@email if @email)}}
+        Subscribe now #{@display_amount}/month
 
-    %p No lock-in. Cancel anytime.
+      %p No lock-in. Cancel anytime.


### PR DESCRIPTION
This adds a basic title tag to the [subscriptions/new](https://www.planningalerts.org.au/subscriptions/new) and subscriptions success pages.

The text simplifies the heading of the pages.

Subscriptions/new: "Get less email & more useful alerts"
Subscriptions success: "Success, subscription confirmed"

closes #640