### PR TITLE
Add <title> tag to subscriptions pages

### DIFF
--- a/app/views/subscriptions/create.html.haml
+++ b/app/views/subscriptions/create.html.haml
@@ -1,3 +1,5 @@
+- content_for :page_title, 'Success, subscription confirmed'
+
 .registration-success-page
   %h1 Success!
 

--- a/app/views/subscriptions/new.html.haml
+++ b/app/views/subscriptions/new.html.haml
@@ -1,3 +1,5 @@
+- content_for :page_title, 'Get less email & more useful alerts'
+
 .registration-page
   = form_tag subscriptions_path, id: 'subscription-payment-form', class: 'registration-intro' do
     %h1 Sift through less email and get more useful&nbsp;alerts


### PR DESCRIPTION
This adds a basic title tag to the [subscriptions/new](https://www.planningalerts.org.au/subscriptions/new) and subscriptions success pages.

The text simplifies the heading of the pages.

Subscriptions/new: "Get less email & more useful alerts"
Subscriptions success: "Success, subscription confirmed"

closes #640