### PR TITLE
desaturate colour of visited applications in applilcations lists

### DIFF
--- a/app/assets/stylesheets/partials/_page.scss
+++ b/app/assets/stylesheets/partials/_page.scss
@@ -323,6 +323,10 @@ body .container .attention {
     &:last-child {
       border-bottom: none;
     }
+
+    a:visited {
+      color: #344355;
+    }
   }
   .description {
     color: $font-color;


### PR DESCRIPTION
User story: When I am searching for specific applications, I want to know which applications I have already looked at, so that I save time by more quickly finding the application I'm looking for.

A citizen who does a lot of searching for applications complained that when they are searching for applications they spend a lot of time unnecessarily looking at applications they have viewed before.

This is a slight change to the colour of visited applications in an applications list to make unvisited applications more prominent and distinguish visited applications. The change in colour is quite minimal with this iteration. If the problem persists we could amplify the difference in colour or try other things like adding some text to 'viewed' applications.

Visited links are desaturated: 
![screen shot 2015-03-02 at 11 46 12 am](https://cloud.githubusercontent.com/assets/1239550/6433987/ee99ee6a-c0d1-11e4-8f87-e0cf5e37ce30.png)

closes #642 